### PR TITLE
サンプルwebアプリ追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enable": true
+}

--- a/deno-web-app/README.md
+++ b/deno-web-app/README.md
@@ -7,10 +7,8 @@
 Deno が未インストールの場合は、以下のスクリプトでインストールできます。
 
 ```bash
-curl -fsSL https://deno.land/x/install/install.sh | sh
+curl -fsSL https://deno.land/install.sh | sh
 ```
-
-インストール後、`~/.deno/bin` を `PATH` に追加してください。
 
 ## 実行方法
 

--- a/deno-web-app/README.md
+++ b/deno-web-app/README.md
@@ -1,0 +1,23 @@
+# Deno Web App
+
+このディレクトリには、Deno を使用したシンプルな Web サーバーの例が含まれています。後のステップでこのアプリを k3s クラスタにデプロイします。
+
+## Deno のインストール
+
+Deno が未インストールの場合は、以下のスクリプトでインストールできます。
+
+```bash
+curl -fsSL https://deno.land/x/install/install.sh | sh
+```
+
+インストール後、`~/.deno/bin` を `PATH` に追加してください。
+
+## 実行方法
+
+Deno がインストールされていれば、以下のコマンドでサーバーを起動できます。
+
+```bash
+deno run --allow-net main.ts
+```
+
+起動後、`http://localhost:8000` にアクセスすると "Hello, Deno!" と表示されます。

--- a/deno-web-app/main.ts
+++ b/deno-web-app/main.ts
@@ -1,0 +1,10 @@
+import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
+
+const handler = (_req: Request): Response => {
+  return new Response("Hello, Deno!", {
+    headers: { "content-type": "text/plain" },
+  });
+};
+
+console.log("Server running on http://localhost:8000/");
+await serve(handler, { port: 8000 });

--- a/deno-web-app/main.ts
+++ b/deno-web-app/main.ts
@@ -1,5 +1,3 @@
-import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
-
 const handler = (_req: Request): Response => {
   return new Response("Hello, Deno!", {
     headers: { "content-type": "text/plain" },
@@ -7,4 +5,4 @@ const handler = (_req: Request): Response => {
 };
 
 console.log("Server running on http://localhost:8000/");
-await serve(handler, { port: 8000 });
+await Deno.serve({ port: 8000 }, handler);


### PR DESCRIPTION
## Summary
- メイン README を初期状態に戻しました

## Testing
- `curl -fsSL https://deno.land/x/install/install.sh | sh`
- `DENO_TLS_CA_STORE=system deno run --allow-net deno-web-app/main.ts`

------
https://chatgpt.com/codex/tasks/task_e_68518a1538b48324a8ca92d41b7b123f