### PR TITLE
Add Dockerfile for Deno example

### DIFF
--- a/deno-web-app/Dockerfile
+++ b/deno-web-app/Dockerfile
@@ -1,0 +1,6 @@
+FROM denoland/deno:alpine-2.3.6
+WORKDIR /app
+USER deno
+COPY . .
+EXPOSE 8000
+CMD ["run", "--allow-net", "main.ts"]

--- a/deno-web-app/README.md
+++ b/deno-web-app/README.md
@@ -1,6 +1,8 @@
 # Deno Web App
 
-このディレクトリには、Deno を使用したシンプルな Web サーバーの例が含まれています。後のステップでこのアプリを k3s クラスタにデプロイします。
+このディレクトリには、Deno を使用したシンプルな Web
+サーバーの例が含まれています。後のステップでこのアプリを k3s
+クラスタにデプロイします。
 
 ## Deno のインストール
 
@@ -19,3 +21,15 @@ deno run --allow-net main.ts
 ```
 
 起動後、`http://localhost:8000` にアクセスすると "Hello, Deno!" と表示されます。
+
+## Docker での実行
+
+Docker イメージのビルドと実行例です。
+
+```bash
+docker build -t deno-web-app .
+docker run -p 8000:8000 deno-web-app
+```
+
+コンテナ起動後、`http://localhost:8000` にアクセスすると "Hello, Deno!"
+と表示されます。


### PR DESCRIPTION
## Summary
- add Dockerfile for the Deno web app
- document Docker usage
- format README

## Testing
- `deno fmt --check deno-web-app/main.ts deno-web-app/Dockerfile deno-web-app/README.md`
- `deno lint deno-web-app/main.ts`


------
https://chatgpt.com/codex/tasks/task_e_68519f5fc18083249cc9bb332ca3c9fb